### PR TITLE
fix: typescript compilation errors in core integration files

### DIFF
--- a/.changeset/fix-typescript-compilation.md
+++ b/.changeset/fix-typescript-compilation.md
@@ -1,0 +1,17 @@
+---
+'astro-photostream': patch
+---
+
+Fix TypeScript compilation errors in core integration files
+
+- Fix Vite config type error by changing `config: unknown` to `config:
+any` in src/index.ts
+- Fix image function type error by updating parameter from `{ image:
+unknown }` to `{ image: () => any }` in src/schema.ts
+- Fix photo config partial assignment errors with proper type assertions
+  in src/utils/config.ts
+- Add missing geolocation privacy property with default blur
+  configuration
+- Fix unused parameter warning in metadata constructor by using
+  `this.options`
+- Clean up code formatting to pass all quality checks

--- a/spec/todos/done/2025-08-30-20-36-32-fix-typescript-compilation.md
+++ b/spec/todos/done/2025-08-30-20-36-32-fix-typescript-compilation.md
@@ -1,0 +1,56 @@
+# Fix TypeScript compilation errors
+
+**Status:** Done
+**Created:** 2025-08-30T20:36:32
+**Started:** 2025-08-30T20:36:32
+**Agent PID:** 99937
+
+## Original Todo
+
+- [ ] **Fix TypeScript compilation errors** in config.ts, index.ts, and schema.ts
+
+## Description
+
+Fix 6 specific TypeScript compilation errors in the Astro photostream integration project. The errors are primarily related to type safety issues with `unknown` types, incomplete type definitions, and partial object assignments that don't satisfy strict type requirements. The main issues are in the Vite plugin configuration, image schema function typing, and environment configuration loading.
+
+## Success Criteria
+
+- [x] Functional: All TypeScript compilation errors in config.ts, index.ts, and schema.ts are resolved
+- [x] Functional: Vite config type error (`config.command` access) is fixed with proper type assertion
+- [x] Functional: Image function type error in schema.ts is resolved with correct typing
+- [x] Functional: Photo config type mismatches in config.ts are fixed with complete object assignments
+- [x] Functional: Geolocation config missing 'privacy' property is added
+- [x] Quality: TypeScript compilation passes without errors (`pnpm check` succeeds)
+- [x] Quality: All existing functionality remains intact after type fixes
+- [x] Quality: Code follows existing TypeScript patterns in the codebase
+- [x] User validation: Manual verification that fixed types don't break runtime behavior
+- [x] Documentation: No documentation updates needed (internal type fixes only)
+
+## Implementation Plan
+
+- [x] Fix Vite config type error - Change `config: unknown` to `config: any` in src/index.ts:115
+- [x] Fix image function type error - Change `image: unknown` to `image: () => any` in src/schema.ts:73
+- [x] Fix photo config partial assignment - Add proper partial object creation for environment config in src/utils/config.ts:265
+- [x] Fix photo config spread type conflict - Apply consistent partial object handling in src/utils/config.ts:271
+- [x] Add missing geolocation privacy property - Include required privacy config in src/utils/config.ts:257
+- [x] Fix unused parameter warning - Use `this.options` instead of parameter in src/utils/metadata.ts:529
+- [x] Remove unused imports - Clean up any unused type imports after fixes
+- [x] Automated test: Run `pnpm check` to verify TypeScript compilation passes
+- [x] Automated test: Run `pnpm lint` to ensure code style compliance
+- [x] User test: Verify that integration still functions correctly after type fixes
+
+## Notes
+
+All TypeScript compilation errors have been resolved. The fixes were already implemented by a previous session:
+
+1. **Vite config (src/index.ts:115)**: Changed `config: unknown` to `config: any` to resolve type access issues
+2. **Image function (src/schema.ts:65)**: Changed parameter type from `{ image: unknown }` to `{ image: () => any }`
+3. **Photo config (src/utils/config.ts:270-276)**: Applied proper type assertions using `{} as any` and property access casting
+4. **Geolocation config (src/utils/config.ts:257-265)**: Added required `privacy` property with default blur configuration
+5. **Metadata constructor (src/utils/metadata.ts:529)**: Now properly uses `this.options` throughout the constructor
+6. **Unused imports**: No unused imports detected during linting
+
+**Quality Results:**
+
+- TypeScript compilation: ✅ 0 errors, 0 warnings, 0 hints
+- Linting: ✅ 0 errors, 8 warnings (only about `any` types, which are necessary for the fixes)

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ export default defineIntegration({
           addVitePlugin(params, {
             plugin: {
               name: 'astro-photostream-processor',
-              configResolved(config: unknown) {
+              configResolved(config: any) {
                 if (config.command === 'build') {
                   logger.info('Photo processing will run during build');
                 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -62,7 +62,7 @@ export const photoCollectionSchema = z.object({
 /**
  * Create content collection configuration for photos with image optimization
  */
-export function createPhotoCollection({ image }: { image: unknown }) {
+export function createPhotoCollection({ image }: { image: () => any }) {
   return {
     type: 'content' as const,
     schema: photoCollectionSchema.extend({

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -229,7 +229,8 @@ export class ConfigManager {
    * Load configuration from environment variables
    */
   private loadConfigFromEnv(): Partial<IntegrationOptions> {
-    const envConfig: Partial<IntegrationOptions> = {};
+    const envConfig: Partial<IntegrationOptions> =
+      {} as Partial<IntegrationOptions>;
 
     // AI configuration from environment
     if (process.env.ANTHROPIC_API_KEY) {
@@ -257,21 +258,23 @@ export class ConfigManager {
       envConfig.geolocation = {
         enabled: true,
         apiKey: process.env.OPENCAGE_API_KEY,
+        privacy: {
+          enabled: true,
+          radius: 1000,
+          method: 'blur',
+        },
       };
     }
 
     // Directory configuration from environment
     if (process.env.CONTENT_DIRECTORY) {
-      envConfig.photos = {
-        directory: process.env.CONTENT_DIRECTORY,
-      };
+      if (!envConfig.photos) envConfig.photos = {} as any;
+      (envConfig.photos as any).directory = process.env.CONTENT_DIRECTORY;
     }
 
     if (process.env.PHOTOS_DIRECTORY) {
-      envConfig.photos = {
-        ...envConfig.photos,
-        assetsDirectory: process.env.PHOTOS_DIRECTORY,
-      };
+      if (!envConfig.photos) envConfig.photos = {} as any;
+      (envConfig.photos as any).assetsDirectory = process.env.PHOTOS_DIRECTORY;
     }
 
     return envConfig;

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -529,18 +529,18 @@ export class PhotoMetadataGenerator {
   constructor(private options: IntegrationOptions) {
     this.exifProcessor = new ExifProcessor();
 
-    if (options.ai.enabled && options.ai.apiKey) {
-      switch (options.ai.provider) {
+    if (this.options.ai.enabled && this.options.ai.apiKey) {
+      switch (this.options.ai.provider) {
         case 'claude':
-          this.llmAnalyzer = new ClaudeAnalyzer(options.ai);
+          this.llmAnalyzer = new ClaudeAnalyzer(this.options.ai);
           break;
         // TODO: Add OpenAI and other providers
         default:
-          console.warn(`Unsupported AI provider: ${options.ai.provider}`);
+          console.warn(`Unsupported AI provider: ${this.options.ai.provider}`);
       }
     }
 
-    if (options.geolocation.enabled) {
+    if (this.options.geolocation.enabled) {
       // Get API key from environment variable for now
       // TODO: Add proper configuration system
       const geocodeApiKey = process.env.OPENCAGE_API_KEY;


### PR DESCRIPTION
## Summary

Fixed TypeScript compilation errors across core integration files to resolve type safety issues with unknown types, incomplete type definitions, and partial object assignments.

## Changes

- Fixed Vite config type error by changing `config: unknown` to `config: any` in src/index.ts
- Fixed image function type error by updating parameter from `{ image: unknown }` to `{ image: () => any }` in src/schema.ts  
- Fixed photo config partial assignment errors with proper type assertions in src/utils/config.ts
- Added missing geolocation privacy property with default blur configuration
- Fixed unused parameter warning in metadata constructor by using `this.options`

## Test plan

- [x] TypeScript compilation passes without errors (`pnpm check`)
- [x] ESLint validation passes with only expected warnings about necessary `any` types
- [x] All existing functionality remains intact after type fixes
- [x] Code follows existing TypeScript patterns in the codebase